### PR TITLE
fixes for docker build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN apt-get -q update && apt-get install -y -qq \
   unzip \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - \
   && apt-get install -y -q nodejs \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 RUN apt-get update
 RUN apt-get install -y --allow-unauthenticated mongodb-org


### PR DESCRIPTION
This pull request has two fixes for build errors.

Found these two errors while attempting to build & run the MAGE server container via `docker-compose up`

1. `npm: not found`
2. `mongodb-org/3.2 Release is not signed`


### Logs and comments

#### 1. npm: not found

* Fix was to upgrade `node` to version 8
* Full Log
```
Step 16/23 : RUN npm install
 ---> Running in 5b24cd5dd22d
/bin/sh: 1: npm: not found
ERROR: Service 'mage' failed to build: The command '/bin/sh -c npm install' returned a non-zero code: 127
```
-----

#### 2. mongodb-org/3.2 Release is not signed

* Found this link at SO that described a fix for the GPG, https://stackoverflow.com/a/42853088
* MongoDB discussion on keys, https://jira.mongodb.org/browse/SERVER-31459

* error
```
W: GPG error: http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D68FA50FEA312927
E: The repository 'http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release' is not signed.

```

* Full log

```
<snip above>

Step 6/23 : RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
 ---> Running in 1485d67b029f
deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse
Removing intermediate container 1485d67b029f
 ---> 3840b17e58ac
Step 7/23 : RUN apt-get update
 ---> Running in ac16cac89122
Get:1 https://deb.nodesource.com/node_6.x bionic InRelease [4622 B]
Ign:2 http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 InRelease
Get:3 https://deb.nodesource.com/node_6.x bionic/main amd64 Packages [765 B]
Get:4 http://security.ubuntu.com/ubuntu bionic-security InRelease [83.2 kB]
Get:5 http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release [3462 B]
Get:6 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
Get:7 http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release.gpg [801 B]
Ign:7 http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release.gpg
Get:8 http://security.ubuntu.com/ubuntu bionic-security/universe Sources [3792 B]
Get:9 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [52.4 kB]
Get:10 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [1066 B]
Get:11 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [17.1 kB]
Get:12 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [83.2 kB]
Get:13 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [65.5 kB]
Get:14 http://archive.ubuntu.com/ubuntu bionic/universe Sources [11.5 MB]
Get:15 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]
Get:16 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
Get:17 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]
Get:18 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]
Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/universe Sources [7265 B]
Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [1660 B]
Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [73.1 kB]
Get:22 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [33.1 kB]
Reading package lists...
W: GPG error: http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D68FA50FEA312927
E: The repository 'http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 Release' is not signed.
ERROR: Service 'mage' failed to build: The command '/bin/sh -c apt-get update' returned a non-zero code: 100
```



